### PR TITLE
resolved stale js files issue after upgrade

### DIFF
--- a/default.conf
+++ b/default.conf
@@ -10,5 +10,14 @@ server {
     location = /50x.html {
         root   /usr/share/nginx/html;
     }
-    ssi on;
+    location = /plugin-entry.js {
+        root   /opt/app-root/src;
+        expires -1;
+        add_header 'Cache-Control' 'no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0';
+    }
+    location = /plugin-manifest.json {
+        root   /opt/app-root/src;
+        expires -1;
+        add_header 'Cache-Control' 'no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0';
+    }
 }


### PR DESCRIPTION
Tfter updating the container image, the plugin-entry file continued to request old js chunk files.
The root cause is that plugin-entry.js file is cached.
The solution is to update nginx conf to instruct the browser to not cache plugin-entry.js and plugin-manifest.json files