### PR TITLE
small fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
       "nodeHealthCheckDetailsPage": "./components/details/NodeHealthCheckDetailsPage.tsx"
     },
     "dependencies": {
-      "@console/pluginAPI": "^4.11"
+      "@console/pluginAPI": ">=4.11.0-0"
     }
   },
   "dependencies": {

--- a/src/components/editor/formView/NodeHealthCheckFormFields.tsx
+++ b/src/components/editor/formView/NodeHealthCheckFormFields.tsx
@@ -22,7 +22,7 @@ const MinHealthyField = ({ fieldName }: FormViewFieldProps) => {
       labelIcon={
         <HelpIcon
           helpText={t(
-            "The minimum number or percentage of nodes that has to be healthy for the remediation to start."
+            "The minimum percentage or number of nodes that has to be healthy for the remediation to start."
           )}
         />
       }

--- a/src/copiedFromConsole/utils/details-item.tsx
+++ b/src/copiedFromConsole/utils/details-item.tsx
@@ -67,7 +67,7 @@ export const DetailsItem: React.FC<DetailsItemProps> = ({
 }) => {
   const { t } = useNodeHealthCheckTranslation();
   const hide = hideEmpty && isEmpty(get(obj, path));
-  const value: React.ReactNode = children || get(obj, path, defaultValue);
+  const value: React.ReactNode = children ?? get(obj, path, defaultValue);
   const editable = onEdit && canEdit;
   return hide ? null : (
     <>


### PR DESCRIPTION
1. changed the dependency on console plugin to "*" because of semver 6 bug that causes it to fail for version 4.11.0-0.nightly-...
2. fixed details view to show "0" and not "-" for observed and healthy nodes
3. fixed info message on minHealthy to show percentage first