### PR TITLE
ECOPROJECT-1671: Replacing other remediation template with SNR template during editing action

### DIFF
--- a/src/data/formViewValues.ts
+++ b/src/data/formViewValues.ts
@@ -84,7 +84,11 @@ export const getFormViewValues = (
       nodeHealthCheck.spec?.minHealthy ?? DEFAULT_MIN_HEALTHY
     ).toString(),
     unhealthyConditions: getUnhealthyConditionsValue(nodeHealthCheck),
-    remediator: !useEscalating ? getRemediationTemplateFormValues() : undefined,
+    remediator: !useEscalating
+      ? getRemediationTemplateFormValues(
+          nodeHealthCheck?.spec?.remediationTemplate
+        )
+      : undefined,
     escalatingRemediations: getescalatingRemediationsFormValues(
       nodeHealthCheck.spec?.escalatingRemediations
     ),


### PR DESCRIPTION
Fixed edit of other remediation template to show custom template and not SNR