### PR TITLE
change default snr template to be determined according to label 

### DIFF
--- a/src/components/editor/NodeHealthCheckSyncedEditor.tsx
+++ b/src/components/editor/NodeHealthCheckSyncedEditor.tsx
@@ -2,7 +2,11 @@ import * as React from "react";
 
 import { useFormikContext } from "formik";
 import { useNodeHealthCheckTranslation } from "localization/useNodeHealthCheckTranslation";
-import { NodeHealthCheck, NodeHealthCheckFormValues } from "../../data/types";
+import {
+  NodeHealthCheck,
+  NodeHealthCheckFormValues,
+  RemediationTemplate,
+} from "../../data/types";
 import { EditorType } from "../../copiedFromConsole/synced-editor/editor-toggle";
 import {
   FlexForm,
@@ -18,6 +22,7 @@ import { dump } from "js-yaml";
 import { Alert, FormSection } from "@patternfly/react-core";
 import { getFormValues } from "data/formValues";
 import { isEmpty } from "lodash-es";
+
 const sanitizeToYaml = (
   values: NodeHealthCheckFormValues,
   originalNodeHealthCheck: NodeHealthCheck
@@ -40,11 +45,12 @@ const LAST_VIEWED_EDITOR_TYPE_USERSETTING_KEY =
 type NodeHealthCheckFormSyncedEditorProps = {
   handleCancel: () => void;
   originalNodeHealthCheck: NodeHealthCheck;
+  snrTemplate: RemediationTemplate;
 };
 
 export const NodeHealthCheckSyncedEditor: React.FC<
   NodeHealthCheckFormSyncedEditorProps
-> = ({ originalNodeHealthCheck, handleCancel }) => {
+> = ({ originalNodeHealthCheck, handleCancel, snrTemplate }) => {
   const {
     values,
     status,
@@ -96,7 +102,11 @@ export const NodeHealthCheckSyncedEditor: React.FC<
 
   const onReload = () => {
     const curEditorType = values.editorType;
-    const resetValues = getFormValues(originalNodeHealthCheck, false);
+    const resetValues = getFormValues(
+      originalNodeHealthCheck,
+      false,
+      snrTemplate
+    );
     resetValues.editorType = curEditorType;
     resetValues.reloadCount++;
     resetForm({ values: resetValues });
@@ -105,6 +115,7 @@ export const NodeHealthCheckSyncedEditor: React.FC<
   React.useEffect(() => {
     setStatus({ submitError: null });
   }, [setStatus, values.editorType]);
+
   return (
     <>
       <FlexForm className="nhc-form">
@@ -115,11 +126,17 @@ export const NodeHealthCheckSyncedEditor: React.FC<
             editor: formEditor,
             sanitizeTo: (yamlNodeHealthCheck: NodeHealthCheck) => {
               try {
-                return formViewValues.getFormViewValues(yamlNodeHealthCheck);
+                return formViewValues.getFormViewValues(
+                  yamlNodeHealthCheck,
+                  snrTemplate
+                );
               } catch (err) {
                 //return a function so SyncedEditorField will handle the error properly
                 return () =>
-                  formViewValues.getFormViewValues(originalNodeHealthCheck);
+                  formViewValues.getFormViewValues(
+                    originalNodeHealthCheck,
+                    snrTemplate
+                  );
               }
             },
           }}

--- a/src/components/editor/formView/remediatorField/RemediatorKindField.tsx
+++ b/src/components/editor/formView/remediatorField/RemediatorKindField.tsx
@@ -17,21 +17,6 @@ import {
   RemediationTemplate,
 } from "../../../../data/types";
 import { useNodeHealthCheckTranslation } from "../../../../localization/useNodeHealthCheckTranslation";
-import HelpIcon from "../../../shared/HelpIcon";
-
-const SNRRadioButtonLabel: React.FC = () => {
-  const { t } = useNodeHealthCheckTranslation();
-  return (
-    <>
-      {getSNRLabel(t)}
-      <HelpIcon
-        helpText={t(
-          "Self node remediation template uses the remediation strategy 'Resource Deletion'."
-        )}
-      />
-    </>
-  );
-};
 
 const RemediatorKindRadioGroup: React.FC<{
   snrTemplatesExist: boolean;
@@ -50,7 +35,7 @@ const RemediatorKindRadioGroup: React.FC<{
       >
         <RadioButtonField
           value={RemediatorRadioOption.SNR}
-          label={<SNRRadioButtonLabel />}
+          label={getSNRLabel(t)}
           isDisabled={!snrTemplatesExist}
           aria-describedby={"SNR remediator kind"}
           name={fieldName}

--- a/src/data/formValues.ts
+++ b/src/data/formValues.ts
@@ -4,6 +4,7 @@ import {
   FormViewValues,
   NodeHealthCheck,
   NodeHealthCheckFormValues,
+  RemediationTemplate,
 } from "./types";
 import { dump } from "js-yaml";
 import { isParseError } from "./parseErrors";
@@ -13,7 +14,8 @@ import * as yamlText from "./yamlText";
 
 export const getFormValues = (
   nodeHealthCheck: NodeHealthCheck,
-  isCreateFlow: boolean
+  isCreateFlow: boolean,
+  snrTemplate: RemediationTemplate | undefined
 ): NodeHealthCheckFormValues => {
   const yamlData = dump(nodeHealthCheck, {
     skipInvalid: true,
@@ -22,7 +24,7 @@ export const getFormValues = (
   let formData: FormViewValues | null = null;
   let editorType = EditorType.YAML;
   try {
-    formData = getFormViewValues(nodeHealthCheck);
+    formData = getFormViewValues(nodeHealthCheck, snrTemplate);
     editorType = EditorType.Form;
   } catch (err) {
     if (isParseError(err)) {


### PR DESCRIPTION
[ECOPROJECT-1808](https://issues.redhat.com/browse/ECOPROJECT-1808)
Following change of default strategy to auto instead of resource deletion, it was decided to use a label to determine the default template for the UI

Auto template
![image_720](https://github.com/medik8s/node-remediation-console/assets/22211154/0b83ce8a-8c64-4973-9317-2ac490b99f60)

Resource deletion template turns to a custom template
![image_720](https://github.com/medik8s/node-remediation-console/assets/22211154/b531b83e-5174-46b5-bbb0-0ab1d89cf7f7)
