### PR TITLE
fix failing CI by bumping node version to 18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/nodejs-16:latest AS builder
+FROM registry.access.redhat.com/ubi8/nodejs-18:latest AS builder
 ARG VERSION=0.0.1
 USER root
 RUN npm install -g corepack


### PR DESCRIPTION
<!-- Thanks for contributing to our project! We appreciate your time and effort.
Please fill out the information below to expedite the review and merge of your pull request.
-->

#### Why we need this PR
<!--
Outline the purpose of this PR, whether it's addressing a bug, implementing a new feature, or solving a specific problem.
-->
CI fails because access to registry doesn't work with nodejs-16 image 
#### Changes made
<!-- Outline the specific changes made in this merge request. -->
upgraded to nodejs-18 image in Dockerfile
