### PR TITLE
Modernize GitHub Actions workflow versions

### DIFF
--- a/.github/workflows/post-submit.yaml
+++ b/.github/workflows/post-submit.yaml
@@ -12,12 +12,12 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Log in to Quay.io
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}

--- a/.github/workflows/pre-submit.yaml
+++ b/.github/workflows/pre-submit.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
 


### PR DESCRIPTION
#### Why we need this PR
Modernize GitHub Actions to current stable versions.

#### Changes made
- Bump `actions/checkout` from v3 to v6
- Bump `docker/login-action` from v2 to v4

#### Which issue(s) this PR fixes
Contributes to [RHWA-852](https://redhat.atlassian.net/browse/RHWA-852)

#### Test plan
- CI pre-submit passes with updated action versions