### PR TITLE
Direct nginx logs to stdout/stderr

### DIFF
--- a/default.conf
+++ b/default.conf
@@ -3,6 +3,8 @@ server {
     ssl_certificate /var/serving-cert/tls.crt;
     ssl_certificate_key /var/serving-cert/tls.key;
     ssl_protocols TLSv1.2 TLSv1.3;
+    access_log /dev/stdout;
+    error_log /dev/stderr warn;
     location / {
         root   /opt/app-root/src;
     }


### PR DESCRIPTION
## Why we need this PR

The nginx console plugin writes nothing to stdout/stderr by default, failing the certsuite container logging best practice test ([RHWA-987](https://redhat.atlassian.net/browse/RHWA-987)). Containers must emit logs to standard streams for Kubernetes log collection to work.

## Changes made

Added `access_log /dev/stdout;` and `error_log /dev/stderr warn;` directives to the nginx server block in `default.conf`.

## How to test

1. Build and deploy the console plugin
2. Verify nginx access and error logs appear in `kubectl logs`
3. Confirm certsuite container logging test passes

## Related

- [RHWA-987](https://redhat.atlassian.net/browse/RHWA-987)